### PR TITLE
Make it easier to install Trollibox by having a README that doesn't result in errors along the way.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ The following tools are required to build Trollibox:
 
 To build:
 ```sh
-# Set up a GOPATH if you haven't already
+# Set up a GOPATH if you haven't already, and make sure GOPATH/bin is in your path
 export GOPATH="$PWD/gopath"
+export PATH=$PATH:$GOPATH/bin
 mkdir -p $GOPATH/src/github.com/polyfloyd
 
 # Download Trollibox
-git clone https://github.com/polyfloyd/trollibox.git $GOPATH/src/github.com/polyfloyd/trollibox
+git clone --recurse-submodules -j8 https://github.com/polyfloyd/trollibox.git $GOPATH/src/github.com/polyfloyd/trollibox
 cd $GOPATH/src/github.com/polyfloyd/trollibox
 
 # Install dependencies


### PR DESCRIPTION
Updated the README to set the PATH correctly (which is needed in the ./just install step) and to clone the submodules as well.