### PR TITLE
Added event emitter to set track time to zero in SetTrackIndex function for MPD players, fixes #12

### DIFF
--- a/src/player/mpd/mpd.go
+++ b/src/player/mpd/mpd.go
@@ -401,6 +401,8 @@ func (pl *Player) SetTrackIndex(trackIndex int) error {
 		} else if trackIndex >= plistLen {
 			return pl.setStateWith(mpdc, player.PlayStateStopped)
 		}
+		// Send a event to set the time to zero so that web clients won't keep running on a previous' tracks time
+		pl.Emit(player.TimeEvent{Time: 0})
 		return mpdc.Play(trackIndex)
 	})
 }


### PR DESCRIPTION
This PR adds a event that will be sent after the track index is set/changed. This will allow clients to see the proper track duration after a user skips a track or after a track transitions into another.